### PR TITLE
Fix not compiling code samples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,29 @@
 [![Crates.io](https://img.shields.io/crates/v/iroh-topic-tracker.svg)](https://crates.io/crates/iroh-topic-tracker)
 [![Docs.rs](https://docs.rs/iroh-topic-tracker/badge.svg)](https://docs.rs/iroh-topic-tracker)
 
-**A tracker for Iroh NodeId's in GossipSub topics.**  
-This library integrates with [`iroh-gossip`](https://crates.io/crates/iroh-gossip) to automate peer discovery and includes a hosted `BOOTSTRAP_NODE` for seamless topic tracking without you needing to host anything. Your peers can discover each other even if both are behind NATs.
+**A tracker for Iroh NodeId's in GossipSub topics.**
+
+This library integrates with
+[`iroh-gossip`](https://crates.io/crates/iroh-gossip) to automate peer
+discovery and includes a hosted `BOOTSTRAP_NODE` for seamless topic tracking
+without you needing to host anything. Your peers can discover each other even
+if both are behind NATs.
 
 ---
 
 ## Overview
 
-The crate provides a [`TopicTracker`](https://docs.rs/iroh-topic-tracker/latest/iroh_topic_tracker/topic_tracker/struct.TopicTracker.html) to manage and discover peers participating in shared GossipSub topics. It leverages Iroh's direct connectivity and [`Router`](https://docs.rs/iroh/latest/iroh/protocol/struct.Router.html) to handle protocol routing.
+The crate provides a
+[`TopicTracker`](https://docs.rs/iroh-topic-tracker/latest/iroh_topic_tracker/topic_tracker/struct.TopicTracker.html)
+to manage and discover peers participating in shared GossipSub topics. It
+leverages Iroh's direct connectivity and
+[`Router`](https://docs.rs/iroh/latest/iroh/protocol/struct.Router.html) to
+handle protocol routing.
 
 ### Features
-- Automatic peer discovery via `iroh-gossip` (enabled with `iroh-gossip-auto-discovery` feature).
+
+- Automatic peer discovery via `iroh-gossip` (enabled with
+  `iroh-gossip-auto-discovery` feature).
 - Dedicated bootstrap node support for topic tracking.
 - Simple API to fetch active peers for a topic.
 
@@ -22,14 +34,18 @@ The crate provides a [`TopicTracker`](https://docs.rs/iroh-topic-tracker/latest/
 ## Getting Started
 
 ### Prerequisites
+
 Add the crate to your `Cargo.toml` with the required features:
+
 ```toml
 [dependencies]
 iroh-topic-tracker = { version = "0.1", features = ["iroh-gossip-auto-discovery"] }
 ```
 
 ### Automatic Discovery
+
 Enable `iroh-gossip` integration to automate peer discovery for topics:
+
 ```rust
 use futures_lite::StreamExt;
 use iroh::Endpoint;
@@ -68,6 +84,7 @@ async fn main() -> anyhow::Result<()> {
 ```
 
 ### Basic Setup with Iroh
+
 ```rust
 use iroh::{protocol::Router, Endpoint};
 use iroh_topic_tracker::topic_tracker::{Topic, TopicTracker};
@@ -94,20 +111,25 @@ async fn main() -> anyhow::Result<()> {
 }
 ```
 
-
 ---
 
 ## Examples
 
 ### Run a Topic Tracker Node
+
 Start a dedicated tracker node:
+
 ```bash
 cargo run --example server
 ```
-*Note: Update `secret.rs` with your `SecretKey` and configure `BOOTSTRAP_NODES` in `topic_tracker.rs` for secure communication.*
+
+*Note: Update `secret.rs` with your `SecretKey` and configure `BOOTSTRAP_NODES`
+in `topic_tracker.rs` for secure communication.*
 
 ### Query Active Peers
+
 Fetch the latest NodeIds for a topic:
+
 ```bash
 cargo run --example client
 ```
@@ -117,6 +139,7 @@ cargo run --example client
 ## Building
 
 Optimized release build for the tracker server:
+
 ```bash
 cargo build --release --example server
 ```
@@ -136,4 +159,6 @@ at your option.
 
 ### Contribution
 
-Unless explicitly stated, any contribution intentionally submitted for inclusion in this project shall be dual-licensed as above, without any additional terms or conditions.
+Unless explicitly stated, any contribution intentionally submitted for
+inclusion in this project shall be dual-licensed as above, without any
+additional terms or conditions.

--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ cargo build --release --example server
 
 This project is licensed under either of
 
-- Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+- Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE.txt) or
   <http://www.apache.org/licenses/LICENSE-2.0>)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or
+- MIT license ([LICENSE-MIT](LICENSE-MIT.txt) or
   <http://opensource.org/licenses/MIT>)
 
 at your option.

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -10,16 +10,16 @@ async fn main() -> Result<()> {
     let _topic_id: TopicId = topic.clone().into();
 
     // Generate a new secret key for secure communication
-    let secret_key =  SecretKey::generate(rand::rngs::OsRng);
-    
+    let secret_key = SecretKey::generate(rand::rngs::OsRng);
+
     // Configure and initialize the network endpoint
     let endpoint = Endpoint::builder()
         .secret_key(secret_key)
-        .discovery_n0()      // Enable node discovery
-        .discovery_dht()     // Enable DHT discovery
+        .discovery_n0() // Enable node discovery
+        .discovery_dht() // Enable DHT discovery
         .bind()
         .await?;
-    
+
     // Create a shared topic tracker instance
     let topic_tracker = TopicTracker::new(&endpoint);
 
@@ -31,7 +31,8 @@ async fn main() -> Result<()> {
 
     // Query nodes participating in this topic
     let node_ids_for_topic = topic_tracker.get_topic_nodes(&topic).await?;
-    println!("Iroh node_ids for topic: {:?}",node_ids_for_topic);
+    println!("Iroh node_ids for topic: {:?}", node_ids_for_topic);
 
     Ok(())
 }
+


### PR DESCRIPTION
This PR contains some cleanups for `README`, ordered by how important I believe them to be.

- make code samples compileable
- fix broken links
- use more common Markdown style

Please feel free to pick a subset, but ideally at least let's fix the code samples (this got me stuck for some time).

I was also debating with myself whether the contents of the `README` should move into `src/lib.rs` as library docs so they show up on docs.rs, but that might require some workflow changes for you (e.g., switch to generating `README` with [`cargo readme`](https://github.com/webern/cargo-readme)), so I left this out. Personally I think this would be a good direction as I feel comments in code are much more accessible than a README, especially if the code is pulled as a dependency.